### PR TITLE
Fix iRacing emulator

### DIFF
--- a/shmd-dumper/main.cpp
+++ b/shmd-dumper/main.cpp
@@ -1,6 +1,5 @@
 #include <chrono>
 #include <iostream>
-#include <thread>
 
 #include <boost/program_options.hpp>
 #include <fstream>

--- a/shmd-lib/ac/emulator_acc.cpp
+++ b/shmd-lib/ac/emulator_acc.cpp
@@ -77,6 +77,9 @@ void Emulator::update(const std::vector<char>& bytes) {
 }
 
 void Emulator::stop() {
+    if (m_graphicsACC.mapFileBuffer == nullptr) {
+        return;
+    }
     ((SPageFileGraphicACC*)m_graphicsACC.mapFileBuffer)->status = AC_OFF;
     CloseHandle(m_graphicsACC.mapFileBuffer);
     CloseHandle(m_physicsACC.mapFileBuffer);

--- a/shmd-lib/iracing/connector_iracing.cpp
+++ b/shmd-lib/iracing/connector_iracing.cpp
@@ -2,9 +2,6 @@
 
 #include "data_iracing.h"
 
-#include <exception>
-#include <iostream>
-
 namespace iRacing {
 
 bool Connector::connect(int timeoutMs) {

--- a/shmd-lib/iracing/connector_iracing.cpp
+++ b/shmd-lib/iracing/connector_iracing.cpp
@@ -1,5 +1,7 @@
 #include "connector_iracing.h"
 
+#include "data_iracing.h"
+
 namespace iRacing {
 bool Connector::connect(int timeoutMs) {
     bool result = irsdk_startup();

--- a/shmd-lib/iracing/connector_iracing.cpp
+++ b/shmd-lib/iracing/connector_iracing.cpp
@@ -2,7 +2,11 @@
 
 #include "data_iracing.h"
 
+#include <exception>
+#include <iostream>
+
 namespace iRacing {
+
 bool Connector::connect(int timeoutMs) {
     bool result = irsdk_startup();
     if (result) {
@@ -46,8 +50,10 @@ std::vector<char> Connector::update(int timeoutMs) {
                 data.sessionInfo = std::string(irsdk_getSessionInfoStr());
             }
 
-            const irsdk_varHeader* headerEntry = irsdk_getVarHeaderEntry(0);
-            data.headerEntry = *headerEntry;
+            data.headerEntries.reserve(header->numVars);
+            for (int i = 0; i < header->numVars; i++) {
+                data.headerEntries.push_back(*irsdk_getVarHeaderEntry(i));
+            }
             data.header = *header;
 
             auto result = serializeData(data);

--- a/shmd-lib/iracing/connector_iracing.h
+++ b/shmd-lib/iracing/connector_iracing.h
@@ -5,6 +5,7 @@
 #include "connector.h"
 
 namespace iRacing {
+
 class Connector : public ::Connector {
     int rawDataLength{};
     int sessionInfoUpdate{};

--- a/shmd-lib/iracing/connector_iracing.h
+++ b/shmd-lib/iracing/connector_iracing.h
@@ -1,11 +1,8 @@
 #pragma once
 
 #include <memory>
-#include <optional>
-#include <string>
 
 #include "connector.h"
-#include "data_iracing.h"
 
 namespace iRacing {
 class Connector : public ::Connector {

--- a/shmd-lib/iracing/data_iracing.h
+++ b/shmd-lib/iracing/data_iracing.h
@@ -8,9 +8,10 @@
 #include "irsdk/irsdk_defines.h"
 
 namespace iRacing {
+
 struct Data {
     irsdk_header header;
-    irsdk_varHeader headerEntry;
+    std::vector<irsdk_varHeader> headerEntries;
     std::string sessionInfo;
     size_t rawDataLength{};
     std::unique_ptr<char[]> rawData;

--- a/shmd-lib/iracing/emulator_iracing.cpp
+++ b/shmd-lib/iracing/emulator_iracing.cpp
@@ -67,11 +67,17 @@ void Emulator::update(const std::vector<char>& bytes) {
         if (data.header.varBuf[latest].tickCount < data.header.varBuf[i].tickCount)
             latest = i;
 
-    // memcpy(m_sharedMem + data.header.varBuf[latest].bufOffset, data.rawData.get(), data.header.bufLen);
-    // memcpy(m_sharedMem + data.header.varHeaderOffset, &data.headerEntry, sizeof(data.headerEntry));
-    // if (!data.sessionInfo.empty()) {
-    //     memcpy(m_sharedMem + data.header.sessionInfoOffset, data.sessionInfo.c_str(), data.sessionInfo.size());
-    // }
+    memcpy(m_sharedMem + data.header.varBuf[latest].bufOffset,
+           data.rawData.get(),
+           data.header.bufLen);
+
+    memcpy(m_sharedMem + data.header.varHeaderOffset,
+           &data.headerEntries[0],
+           sizeof(irsdk_varHeader) * data.header.numVars);
+
+    if (!data.sessionInfo.empty()) {
+        memcpy(m_sharedMem + data.header.sessionInfoOffset, data.sessionInfo.c_str(), data.sessionInfo.size());
+    }
 }
 
 Emulator::~Emulator() {

--- a/shmd-lib/iracing/emulator_iracing.cpp
+++ b/shmd-lib/iracing/emulator_iracing.cpp
@@ -1,10 +1,9 @@
 #include "emulator_iracing.h"
 
 #include <cassert>
-#include <iostream>
 #include <stdexcept>
 
-#include "connector_iracing.h"
+#include "data_iracing.h"
 #include "irsdk_defines.h"
 
 namespace iRacing {
@@ -80,6 +79,9 @@ Emulator::~Emulator() {
 }
 
 void Emulator::stop() {
+    if (m_sharedMem == nullptr) {
+        return;
+    }
     UnmapViewOfFile(m_sharedMem);
     CloseHandle(m_fileMappingHandle);
     CloseHandle(m_memMapFile);

--- a/shmd-lib/iracing/emulator_iracing.cpp
+++ b/shmd-lib/iracing/emulator_iracing.cpp
@@ -67,11 +67,11 @@ void Emulator::update(const std::vector<char>& bytes) {
         if (data.header.varBuf[latest].tickCount < data.header.varBuf[i].tickCount)
             latest = i;
 
-    memcpy(m_sharedMem + data.header.varBuf[latest].bufOffset, data.rawData.get(), data.header.bufLen);
-    memcpy(m_sharedMem + data.header.varHeaderOffset, &data.headerEntry, sizeof(data.headerEntry));
-    if (!data.sessionInfo.empty()) {
-        memcpy(m_sharedMem + data.header.sessionInfoOffset, data.sessionInfo.c_str(), data.sessionInfo.size());
-    }
+    // memcpy(m_sharedMem + data.header.varBuf[latest].bufOffset, data.rawData.get(), data.header.bufLen);
+    // memcpy(m_sharedMem + data.header.varHeaderOffset, &data.headerEntry, sizeof(data.headerEntry));
+    // if (!data.sessionInfo.empty()) {
+    //     memcpy(m_sharedMem + data.header.sessionInfoOffset, data.sessionInfo.c_str(), data.sessionInfo.size());
+    // }
 }
 
 Emulator::~Emulator() {

--- a/shmd-tests/data_iracing_test.cpp
+++ b/shmd-tests/data_iracing_test.cpp
@@ -16,13 +16,13 @@ protected:
         testData.header.numBuf = 1;
         testData.header.bufLen = 40;
 
-        testData.headerEntry.type = 1;
-        testData.headerEntry.offset = 2;
-        testData.headerEntry.count = 3;
-        testData.headerEntry.countAsTime = true;
-        strcpy_s(testData.headerEntry.name, "TestName");
-        strcpy_s(testData.headerEntry.desc, "TestDesc");
-        strcpy_s(testData.headerEntry.unit, "TestUnit");
+        // testData.headerEntry.type = 1;
+        // testData.headerEntry.offset = 2;
+        // testData.headerEntry.count = 3;
+        // testData.headerEntry.countAsTime = true;
+        // strcpy_s(testData.headerEntry.name, "TestName");
+        // strcpy_s(testData.headerEntry.desc, "TestDesc");
+        // strcpy_s(testData.headerEntry.unit, "TestUnit");
 
         testData.sessionInfo = "Sample session info";
 
@@ -53,13 +53,13 @@ void compareData(const iRacing::Data& lhs, const iRacing::Data& rhs) {
     EXPECT_EQ(lhs.header.numBuf, rhs.header.numBuf);
     EXPECT_EQ(lhs.header.bufLen, rhs.header.bufLen);
 
-    EXPECT_EQ(lhs.headerEntry.type, rhs.headerEntry.type);
-    EXPECT_EQ(lhs.headerEntry.offset, rhs.headerEntry.offset);
-    EXPECT_EQ(lhs.headerEntry.count, rhs.headerEntry.count);
-    EXPECT_EQ(lhs.headerEntry.countAsTime, rhs.headerEntry.countAsTime);
-    EXPECT_STREQ(lhs.headerEntry.name, rhs.headerEntry.name);
-    EXPECT_STREQ(lhs.headerEntry.desc, rhs.headerEntry.desc);
-    EXPECT_STREQ(lhs.headerEntry.unit, rhs.headerEntry.unit);
+    // EXPECT_EQ(lhs.headerEntry.type, rhs.headerEntry.type);
+    // EXPECT_EQ(lhs.headerEntry.offset, rhs.headerEntry.offset);
+    // EXPECT_EQ(lhs.headerEntry.count, rhs.headerEntry.count);
+    // EXPECT_EQ(lhs.headerEntry.countAsTime, rhs.headerEntry.countAsTime);
+    // EXPECT_STREQ(lhs.headerEntry.name, rhs.headerEntry.name);
+    // EXPECT_STREQ(lhs.headerEntry.desc, rhs.headerEntry.desc);
+    // EXPECT_STREQ(lhs.headerEntry.unit, rhs.headerEntry.unit);
 
     EXPECT_EQ(lhs.sessionInfo, rhs.sessionInfo);
 

--- a/shmd-tests/data_iracing_test.cpp
+++ b/shmd-tests/data_iracing_test.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include "data_iracing.h"
+#include "irsdk_defines.h"
 
 class iRacingDataTest : public ::testing::Test {
 protected:
@@ -16,13 +17,31 @@ protected:
         testData.header.numBuf = 1;
         testData.header.bufLen = 40;
 
-        // testData.headerEntry.type = 1;
-        // testData.headerEntry.offset = 2;
-        // testData.headerEntry.count = 3;
-        // testData.headerEntry.countAsTime = true;
-        // strcpy_s(testData.headerEntry.name, "TestName");
-        // strcpy_s(testData.headerEntry.desc, "TestDesc");
-        // strcpy_s(testData.headerEntry.unit, "TestUnit");
+        {
+            irsdk_varHeader headerEntry;
+            headerEntry.type = 1;
+            headerEntry.offset = 2;
+            headerEntry.count = 3;
+            headerEntry.countAsTime = true;
+            strcpy_s(headerEntry.name, "TestName");
+            strcpy_s(headerEntry.desc, "TestDesc");
+            strcpy_s(headerEntry.unit, "TestUnit");
+
+            testData.headerEntries.push_back(headerEntry);
+        }
+
+        {
+            irsdk_varHeader headerEntry;
+            headerEntry.type = 2;
+            headerEntry.offset = 3;
+            headerEntry.count = 4;
+            headerEntry.countAsTime = true;
+            strcpy_s(headerEntry.name, "TestName2");
+            strcpy_s(headerEntry.desc, "TestDesc2");
+            strcpy_s(headerEntry.unit, "TestUnit2");
+
+            testData.headerEntries.push_back(headerEntry);
+        }
 
         testData.sessionInfo = "Sample session info";
 
@@ -53,13 +72,15 @@ void compareData(const iRacing::Data& lhs, const iRacing::Data& rhs) {
     EXPECT_EQ(lhs.header.numBuf, rhs.header.numBuf);
     EXPECT_EQ(lhs.header.bufLen, rhs.header.bufLen);
 
-    // EXPECT_EQ(lhs.headerEntry.type, rhs.headerEntry.type);
-    // EXPECT_EQ(lhs.headerEntry.offset, rhs.headerEntry.offset);
-    // EXPECT_EQ(lhs.headerEntry.count, rhs.headerEntry.count);
-    // EXPECT_EQ(lhs.headerEntry.countAsTime, rhs.headerEntry.countAsTime);
-    // EXPECT_STREQ(lhs.headerEntry.name, rhs.headerEntry.name);
-    // EXPECT_STREQ(lhs.headerEntry.desc, rhs.headerEntry.desc);
-    // EXPECT_STREQ(lhs.headerEntry.unit, rhs.headerEntry.unit);
+    for (int i = 0; i < lhs.header.numVars; i++) {
+        EXPECT_EQ(lhs.headerEntries[i].type, rhs.headerEntries[i].type);
+        EXPECT_EQ(lhs.headerEntries[i].offset, rhs.headerEntries[i].offset);
+        EXPECT_EQ(lhs.headerEntries[i].count, rhs.headerEntries[i].count);
+        EXPECT_EQ(lhs.headerEntries[i].countAsTime, rhs.headerEntries[i].countAsTime);
+        EXPECT_STREQ(lhs.headerEntries[i].name, rhs.headerEntries[i].name);
+        EXPECT_STREQ(lhs.headerEntries[i].desc, rhs.headerEntries[i].desc);
+        EXPECT_STREQ(lhs.headerEntries[i].unit, rhs.headerEntries[i].unit);
+    }
 
     EXPECT_EQ(lhs.sessionInfo, rhs.sessionInfo);
 


### PR DESCRIPTION
iRacing dumper used to write only the first var header entry, so emulation was unusable